### PR TITLE
Fix last update.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
     </head>
     <body>
         <nav class="site-navigation">
-            <div class="build-date">Poslednji put ažurirano: {{ site.time }}</div>
+            <div class="build-date">Last Updated: {{ site.time }}</div>
             <ul>
                 <li><a href="/#site-header">Dobrodošli</a></li>
                 {% assign lastIsChild = false %}


### PR DESCRIPTION
I truly believe that last update should not be localised, and that it
should remain in english.
When the non-serbian speaking user accesses the site, he will have an
easier time to understand when the site was last updated.
Another point is that it messed up the layout less than the localised
version.
